### PR TITLE
refactor: improve base page interactions and use fixtures in tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
       name: 'ui',
       use: {
         ...devices['Desktop Chrome'],
-        headless: false,
+        headless: true,
         storageState: 'src/.auth/user.json',
       },
       testMatch: /.*\.spec\.ts/,

--- a/src/api/services/customers.service.ts
+++ b/src/api/services/customers.service.ts
@@ -32,7 +32,7 @@ export class CustomersApiService {
       try {
         await this.delete(id);
       } catch (error) {
-        throw new Error(`Failed to delete customer with id ${id}`);
+        throw new Error(`Failed to delete customer with id ${id}: ${error}`);
       }
     }
   }

--- a/src/data/types/home.types.ts
+++ b/src/data/types/home.types.ts
@@ -1,0 +1,12 @@
+export enum CONTAINERS {
+  ORDERS_THIS_YEAR = 'Orders This Year',
+  TOTAL_REVENUE = 'Total Revenue',
+  NEW_CUSTOMERS = 'New Customers',
+  AVG_ORDERS_VALUE = 'Avg Order Value',
+  CANCELED_ORDERS = 'Canceled Orders',
+  CURRENT_MONTH_ORDERS = 'Current Month Orders',
+  TOP_SOLD_PRODUCTS = 'Top Sold Products',
+  CUSTOMER_GROWTH = 'Customer Growth',
+  RECENT_ORDERS = 'Recent Orders',
+  TOP_CUSTOMERS = 'Top Customers',
+}

--- a/src/ui/pages/base.page.ts
+++ b/src/ui/pages/base.page.ts
@@ -66,6 +66,10 @@ export class BasePage {
     await this.page.goto(url);
   }
 
+  async deleteCookies() {
+    await this.page.context().clearCookies();
+  }
+
   async interceptResponse<T>(
     url: string,
     triggerAction: () => Promise<void>,

--- a/src/ui/pages/base.page.ts
+++ b/src/ui/pages/base.page.ts
@@ -1,4 +1,5 @@
 import { Locator, Page } from '@playwright/test';
+import { faker } from '@faker-js/faker';
 
 import { IResponse } from '../../data/types/api.types';
 
@@ -31,6 +32,35 @@ export class BasePage {
     const element = await this.waitForElement(locator, 'visible');
     await element.scrollIntoViewIfNeeded({ timeout });
     return element;
+  }
+
+  protected async waitForSpinnerToHide(
+    spinnerOrSpinners: LocatorOrSelector | LocatorOrSelector[],
+    skipVisibilityCheck: boolean = true,
+  ) {
+    const spinners = Array.isArray(spinnerOrSpinners) ? spinnerOrSpinners : [spinnerOrSpinners];
+    const randomIndex = faker.number.int(spinners.length - 1);
+
+    // Оставляем возможность проверки видимости спиннера
+    if (!skipVisibilityCheck) {
+      try {
+        await this.waitForElement(spinners[randomIndex], 'visible', 3000);
+      } catch (error) {
+        if (spinners.length > 1) {
+          throw new Error(`Random spinner at index ${randomIndex} was not visible: ${error}`);
+        } else {
+          throw new Error(`Spinner was not visible: ${error}`);
+        }
+      }
+    }
+
+    try {
+      for (const spinner of spinners) {
+        await this.waitForElement(spinner, 'hidden');
+      }
+    } catch (error) {
+      throw new Error(`Failed waiting spinner(s) to hide: ${error}`);
+    }
   }
 
   protected async click(locator: LocatorOrSelector, timeout = DEFAULT_TIMEOUT) {

--- a/src/ui/pages/base.page.ts
+++ b/src/ui/pages/base.page.ts
@@ -64,7 +64,7 @@ export class BasePage {
   }
 
   protected async click(locator: LocatorOrSelector, timeout = DEFAULT_TIMEOUT) {
-    const element = await this.waitForElementAndScroll(locator, timeout);
+    const element = await this.waitForElement(locator, 'visible', timeout);
     await element.isEnabled();
     await element.click();
   }
@@ -74,7 +74,7 @@ export class BasePage {
     value: string | number,
     timeout = DEFAULT_TIMEOUT,
   ) {
-    const element = await this.waitForElementAndScroll(locator, timeout);
+    const element = await this.waitForElement(locator, 'visible', timeout);
     await element.fill(String(value), { timeout });
   }
 
@@ -88,7 +88,7 @@ export class BasePage {
     value: string | number,
     timeout = DEFAULT_TIMEOUT,
   ) {
-    const element = await this.waitForElementAndScroll(dropdownLocator, timeout);
+    const element = await this.waitForElement(dropdownLocator, 'visible', timeout);
     await element.selectOption(String(value), { timeout });
   }
 

--- a/src/ui/pages/home.page.ts
+++ b/src/ui/pages/home.page.ts
@@ -1,11 +1,38 @@
+import { CONTAINERS } from '../../data/types/home.types.js';
+
 import { SalesPortalPage } from './salesPortal.page.js';
 
 export class HomePage extends SalesPortalPage {
   uniqueElement = '//strong[.="Admin"]';
 
-  readonly 'Orders button' = this.findElement('#orders-from-home');
-  readonly 'Products button' = this.findElement('#products-from-home');
-  readonly 'Customers button' = this.findElement('#customers-from-home');
+  private readonly 'Orders button' = this.findElement('#orders-from-home');
+  private readonly 'Products button' = this.findElement('#products-from-home');
+  private readonly 'Customers button' = this.findElement('#customers-from-home');
+
+  private readonly containers: Record<CONTAINERS, string> = {
+    [CONTAINERS.ORDERS_THIS_YEAR]: '#total-orders-container',
+    [CONTAINERS.TOTAL_REVENUE]: '#total-revenue-container',
+    [CONTAINERS.NEW_CUSTOMERS]: '#total-customers-container',
+    [CONTAINERS.AVG_ORDERS_VALUE]: '#avg-orders-value-container',
+    [CONTAINERS.CANCELED_ORDERS]: '#canceled-orders-containers',
+    [CONTAINERS.CURRENT_MONTH_ORDERS]: '#orders-chart-container',
+    [CONTAINERS.TOP_SOLD_PRODUCTS]: '#top-products-chart-container',
+    [CONTAINERS.CUSTOMER_GROWTH]: '#customer-growth-chart-container',
+    [CONTAINERS.RECENT_ORDERS]: '#recent-orders-container',
+    [CONTAINERS.TOP_CUSTOMERS]: '#top-customers-container',
+  };
+
+  private readonly getSpinnerByContainerName = (containerName: CONTAINERS) => {
+    const containerSelector = this.containers[containerName];
+    return this.findElement(`${containerSelector} .spinner-border`);
+  };
+
+  async waitForHomeSpinnersToHide() {
+    const spinners = (Object.keys(this.containers) as CONTAINERS[]).map((name) =>
+      this.getSpinnerByContainerName(name),
+    );
+    await this.waitForSpinnerToHide(spinners);
+  }
 
   async clickOnViewDetailsButton(moduleName: 'Products' | 'Customers' | 'Orders') {
     await this.click(this[`${moduleName} button`]);

--- a/src/ui/pages/salesPortal.page.ts
+++ b/src/ui/pages/salesPortal.page.ts
@@ -1,17 +1,22 @@
 import { BasePage } from './base.page.js';
 
 export abstract class SalesPortalPage extends BasePage {
-  protected readonly spinner = this.findElement('div.spinner-border');
   abstract readonly uniqueElement: string;
-  private readonly 'Toast message' = '.toast-body';
-  private readonly 'Close toast button' = '//button[@title="Close"]';
+  private readonly 'Toast message' = this.findElement('.toast-body');
+  private readonly 'Close toast button' = this.findElement('//button[@title="Close"]');
+  private readonly 'Button Spinner' = this.findElement('button .spinner-border');
+  private readonly 'Table spinner' = this.findElement('#table-container .spinner-border');
 
   async waitForOpened() {
     await this.waitForElement(this.uniqueElement);
   }
 
-  async waitForSpinnerToHide() {
-    await this.waitForElement(this.spinner, 'hidden', 15000);
+  async waitForButtonSpinnerToHide() {
+    await this.waitForSpinnerToHide(this['Button Spinner']);
+  }
+
+  async waitForTableSpinnerToHide() {
+    await this.waitForSpinnerToHide(this['Table spinner']);
   }
 
   async getToastMessage() {

--- a/src/ui/services/customers/addNewCustomer.service.ts
+++ b/src/ui/services/customers/addNewCustomer.service.ts
@@ -43,8 +43,9 @@ export class AddCustomerService {
       createdOn: response.body.Customer.createdOn,
       _id: response.body.Customer._id,
     });
-    await this.addNewCustomerPage.waitForSpinnerToHide();
+    await this.addNewCustomerPage.waitForButtonSpinnerToHide();
     await this.customersPage.waitForOpened();
+    await this.customersPage.waitForTableSpinnerToHide();
     return response;
   }
 

--- a/src/ui/services/customers/customers.service.ts
+++ b/src/ui/services/customers/customers.service.ts
@@ -29,14 +29,13 @@ export class CustomersListService {
 
   async openAddNewCustomerPage() {
     await this.customersPage.clickOnAddNewCustomer();
-    await this.customersPage.waitForSpinnerToHide();
     await this.addNewCustomerPage.waitForOpened();
   }
 
   private async repeatSortAction(action: () => Promise<void>, clickCount: number = 1) {
     for (let i = 0; i < clickCount; i++) {
       await action();
-      await this.customersPage.waitForSpinnerToHide();
+      await this.customersPage.waitForTableSpinnerToHide();
     }
   }
 

--- a/src/ui/services/home.service.ts
+++ b/src/ui/services/home.service.ts
@@ -14,7 +14,7 @@ export class HomeService {
 
   async openCustomersPage() {
     await this.homePage.clickOnViewDetailsButton('Customers');
-    await this.homePage.waitForSpinnerToHide();
+    await this.homePage.waitForTableSpinnerToHide();
     await this.customersPage.waitForOpened();
   }
 

--- a/src/ui/services/signIn.service.ts
+++ b/src/ui/services/signIn.service.ts
@@ -35,4 +35,8 @@ export class SignInService {
   async fillInputs(credentials: IUserCredentials) {
     await this.signInPage.fillCredentialsInputs(credentials);
   }
+
+  async clearCookies() {
+    await this.signInPage.deleteCookies();
+  }
 }

--- a/src/ui/services/signIn.service.ts
+++ b/src/ui/services/signIn.service.ts
@@ -23,8 +23,9 @@ export class SignInService {
   async login(credentials: IUserCredentials) {
     await this.signInPage.fillCredentialsInputs(credentials);
     await this.signInPage.clickSubmitButton();
-    await this.signInPage.waitForSpinnerToHide();
+    await this.signInPage.waitForButtonSpinnerToHide();
     await this.homePage.waitForOpened();
+    await this.homePage.waitForHomeSpinnersToHide();
   }
 
   @logStep()

--- a/src/ui/tests/customers/smoke.spec.ts
+++ b/src/ui/tests/customers/smoke.spec.ts
@@ -8,7 +8,8 @@ test.describe('[UI] [Customers] Smoke', async function () {
   });
 
   test.afterEach(async function ({ customersApiService }) {
-    await customersApiService.deleteCustomers(customersIdsToDelete);
+    if (customersIdsToDelete.length > 0)
+      await customersApiService.deleteCustomers(customersIdsToDelete);
     customersIdsToDelete = [];
   });
 

--- a/src/ui/tests/login.spec.ts
+++ b/src/ui/tests/login.spec.ts
@@ -1,29 +1,17 @@
-import { test } from '@playwright/test';
-
-import { ADMIN_PASSWORD, ADMIN_USERNAME, BASE_URL } from '../../config/environment';
+import { test } from '../../fixtures/services.fixtures';
 
 test.describe('[UI] [Login]', async function () {
-  test.beforeEach(async function ({ page }) {
-    await page.context().clearCookies();
-    await page.goto(BASE_URL);
+  test.beforeEach(async function ({ signInPageService }) {
+    await signInPageService.clearCookies();
+    await signInPageService.openSalesPortal();
   });
 
-  test('Login with valid credentials', async function ({ page }) {
-    const emailInput = page.getByLabel('Email address');
-    const passwordInput = page.getByPlaceholder('Enter password');
-    const button = page.getByText('Login', { exact: true });
-    await emailInput.fill(ADMIN_USERNAME);
-    await passwordInput.fill(ADMIN_PASSWORD);
-    await button.click();
-    await page.locator('div.spinner-border').waitFor({ state: 'hidden', timeout: 10000 });
+  test('Login with valid credentials', async function ({ signInPageService }) {
+    await signInPageService.loginAsAdmin();
   });
 
-  test('Open Customers list page', async function ({ page }) {
-    await page.getByLabel('Email address').fill(ADMIN_USERNAME);
-    await page.getByPlaceholder('Enter password').fill(ADMIN_PASSWORD);
-    await page.getByText('Login', { exact: true }).click();
-    await page.locator('div.spinner-border').waitFor({ state: 'hidden', timeout: 10000 });
-    await page.getByRole('link', { name: 'View Customers' }).click();
-    await page.locator('div.spinner-border').waitFor({ state: 'hidden', timeout: 10000 });
+  test('Open Customers list page', async function ({ signInPageService, homePageService }) {
+    await signInPageService.loginAsAdmin();
+    await homePageService.openCustomersPage();
   });
 });


### PR DESCRIPTION
This PR shows the following changes:
- Updated login.spec.ts with fixtures and methods
- Moved waitForSpinnerToHide method from salesPortal.page.ts to base.page.ts and refactored it to meet new spinners selectors. 
- Refactored base page methods using waitForElementAndScroll method. The updated methods don't need scrollIntoViewIfNeeded method (Playwright does it by default), tests were flaky when using waitForElementAndScroll, and now they use waitForElement