### PR TITLE
feat: add logAction, allure reporter and modify globalSetup logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@typescript-eslint/parser": "^8.34.1",
         "ajv": "^8.17.1",
         "allure-commandline": "^2.34.0",
+        "allure-js-commons": "^3.2.2",
         "allure-playwright": "^3.2.2",
         "cross-env": "^7.0.3",
         "dotenv": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@typescript-eslint/parser": "^8.34.1",
     "ajv": "^8.17.1",
     "allure-commandline": "^2.34.0",
+    "allure-js-commons": "^3.2.2",
     "allure-playwright": "^3.2.2",
     "cross-env": "^7.0.3",
     "dotenv": "^16.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
     [
       'allure-playwright',
       {
-        // detail: true,
+        detail: true,
         outputFolder: 'allure-results',
         suiteTitle: false,
       },

--- a/src/api/clients/customers.client.ts
+++ b/src/api/clients/customers.client.ts
@@ -1,10 +1,12 @@
 import { apiConfig } from '../../config/apiConfig';
 import { ICustomer, ICustomerResponse } from '../../data/types/customers.types';
 import { RequestApi } from '../../utils/apiClients/request';
+import { logStep } from '../../utils/report/decorator';
 
 class CustomerApiClient {
   constructor(private request = new RequestApi()) {}
 
+  @logStep('Create customer via API')
   async create(body: ICustomer, token: string) {
     return await this.request.send<ICustomerResponse>({
       url: apiConfig.endpoints.Customers,
@@ -17,6 +19,7 @@ class CustomerApiClient {
     });
   }
 
+  @logStep('Delete customer via API')
   async delete(id: string, token: string) {
     return await this.request.send<ICustomerResponse>({
       url: apiConfig.endpoints.Customers + `/${id}`,
@@ -28,6 +31,7 @@ class CustomerApiClient {
     });
   }
 
+  @logStep('Get customer via API')
   async get(id: string, token: string) {
     return await this.request.send<ICustomerResponse>({
       url: apiConfig.endpoints.Customers + `/${id}`,

--- a/src/api/clients/signIn.client.ts
+++ b/src/api/clients/signIn.client.ts
@@ -2,10 +2,12 @@ import { apiConfig } from '../../config/apiConfig';
 import { IRequestOptions } from '../../data/types/api.types';
 import { ILoginResponse, IUserCredentials } from '../../data/types/user.types';
 import { RequestApi } from '../../utils/apiClients/request';
+import { logStep } from '../../utils/report/decorator';
 
 export class SignInApiClient {
   constructor(private request = new RequestApi()) {}
 
+  @logStep('Sign in via API')
   async login(credentials: IUserCredentials) {
     const options: IRequestOptions = {
       baseURL: apiConfig.baseUrl,

--- a/src/api/services/customers.service.ts
+++ b/src/api/services/customers.service.ts
@@ -6,12 +6,14 @@ import { STATUS_CODES } from '../../data/types/api.types';
 import { ICustomer } from '../../data/types/customers.types';
 import { validateResponse } from '../../utils/validation/response';
 import customersApiClient from '../clients/customers.client';
+import { logStep } from '../../utils/report/decorator';
 
 import signInApi from './signIn.api';
 
 export class CustomersApiService {
   constructor(private customersClient = customersApiClient) {}
 
+  @logStep('Create customer via API')
   async create(customerData?: Partial<ICustomer>) {
     const response = await this.customersClient.create(
       generateNewCustomer(customerData),
@@ -27,6 +29,7 @@ export class CustomersApiService {
     validateResponse(response, STATUS_CODES.DELETED);
   }
 
+  @logStep('Delete customers via API')
   async deleteCustomers(customersIdsToDelete: string[]) {
     for (const id of customersIdsToDelete) {
       try {

--- a/src/api/services/signIn.api.ts
+++ b/src/api/services/signIn.api.ts
@@ -1,14 +1,17 @@
-import { expect } from 'allure-playwright';
+import { expect, request } from '@playwright/test';
 
 import { ADMIN_PASSWORD, ADMIN_USERNAME } from '../../config/environment';
 import { SignInApiClient } from '../clients/signIn.client';
 import { STATUS_CODES } from '../../data/types/api.types';
+import { logStep } from '../../utils/report/decorator';
+import { apiConfig } from '../../config/apiConfig';
 
 class SignInApiService {
   private token?: string;
 
   constructor(private signInClient = new SignInApiClient()) {}
 
+  @logStep('Sign in via API')
   async loginAsAdmin() {
     const response = await this.signInClient.login({
       username: ADMIN_USERNAME,
@@ -19,6 +22,40 @@ class SignInApiService {
     const token = headers.get('authorization');
     this.token = `Bearer ${token}`;
     return response.headers.authorization;
+  }
+
+  // Метод без test.step для использования в globalSetup
+  async loginAsAdminForGlobalSetup() {
+    const requestContext = await request.newContext({
+      baseURL: apiConfig.baseUrl,
+    });
+
+    const response = await requestContext.post(apiConfig.endpoints.Login, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      data: {
+        username: ADMIN_USERNAME,
+        password: ADMIN_PASSWORD,
+      },
+    });
+
+    if (response.status() !== STATUS_CODES.OK) {
+      const body = await response.text();
+      throw new Error(`Login failed with status ${response.status()} and body: ${body}`);
+    }
+
+    const responseHeaders = response.headers();
+    const token = responseHeaders['authorization'];
+
+    if (!token) {
+      throw new Error('Authorization token not found in login response headers');
+    }
+
+    await requestContext.dispose();
+
+    this.token = `Bearer ${token}`;
+    return responseHeaders['authorization'];
   }
 
   async getToken() {

--- a/src/config/global-setup.ts
+++ b/src/config/global-setup.ts
@@ -3,12 +3,11 @@ import { chromium, type FullConfig } from '@playwright/test';
 import signInApiService from '../api/services/signIn.api';
 
 import { BASE_URL } from './environment';
-
 const authFile = 'src/.auth/user.json';
 
 async function globalSetup(config: FullConfig) {
   try {
-    const token = await signInApiService.loginAsAdmin();
+    const token = await signInApiService.loginAsAdminForGlobalSetup();
     const browser = await chromium.launch();
     const page = await browser.newPage();
     await page.context().addCookies([

--- a/src/ui/pages/base.page.ts
+++ b/src/ui/pages/base.page.ts
@@ -2,6 +2,7 @@ import { Locator, Page } from '@playwright/test';
 import { faker } from '@faker-js/faker';
 
 import { IResponse } from '../../data/types/api.types';
+import { logAction } from '../../utils/report/decorator';
 
 const DEFAULT_TIMEOUT = 15000;
 
@@ -63,12 +64,14 @@ export class BasePage {
     }
   }
 
+  @logAction('Click on element with selector {selector}')
   protected async click(locator: LocatorOrSelector, timeout = DEFAULT_TIMEOUT) {
     const element = await this.waitForElement(locator, 'visible', timeout);
     await element.isEnabled();
     await element.click();
   }
 
+  @logAction('Set {text} into element with selector {selector}')
   protected async setValue(
     locator: LocatorOrSelector,
     value: string | number,
@@ -83,6 +86,7 @@ export class BasePage {
     return await element.innerText({ timeout });
   }
 
+  @logAction('Select dropdown value from {selector}')
   protected async selectDropdownValue(
     dropdownLocator: LocatorOrSelector,
     value: string | number,
@@ -92,6 +96,7 @@ export class BasePage {
     await element.selectOption(String(value), { timeout });
   }
 
+  @logAction('Open URL {selector}')
   async openPage(url: string) {
     await this.page.goto(url);
   }

--- a/src/ui/pages/salesPortal.page.ts
+++ b/src/ui/pages/salesPortal.page.ts
@@ -1,3 +1,5 @@
+import { logStep } from '../../utils/report/decorator.js';
+
 import { BasePage } from './base.page.js';
 
 export abstract class SalesPortalPage extends BasePage {
@@ -24,6 +26,7 @@ export abstract class SalesPortalPage extends BasePage {
     return text;
   }
 
+  @logStep('Close toast message')
   async closeToastMessage() {
     await this.click(this['Close toast button']);
     await this.waitForElement(this['Toast message'], 'hidden');

--- a/src/ui/services/customers/addNewCustomer.service.ts
+++ b/src/ui/services/customers/addNewCustomer.service.ts
@@ -9,7 +9,7 @@ import { validateResponse } from '../../../utils/validation/response.js';
 import { STATUS_CODES } from '../../../data/types/api.types.js';
 import { validateToastMessage } from '../../../utils/validation/toastMessage.js';
 import { TOAST_MESSAGES } from '../../../data/messages/messages.js';
-import { logStep } from '../../../utils/report/logStep.js';
+import { logStep } from '../../../utils/report/decorator.js';
 
 export class AddCustomerService {
   private customersPage: CustomersListPage;
@@ -28,7 +28,7 @@ export class AddCustomerService {
     await this.addNewCustomerPage.clickOnSaveButton();
   }
 
-  @logStep()
+  @logStep('Create customer')
   async create(customer?: ICustomer) {
     const customerData = customer ?? generateNewCustomer();
     await this.fillCustomerInputs(customerData);
@@ -49,7 +49,6 @@ export class AddCustomerService {
     return response;
   }
 
-  @logStep()
   async validateCustomerExistsToastMessage(customer: ICustomer) {
     await validateToastMessage(
       this.addNewCustomerPage,

--- a/src/ui/services/customers/customers.service.ts
+++ b/src/ui/services/customers/customers.service.ts
@@ -10,7 +10,7 @@ import {
 import { TABLE_MESSAGES } from '../../../data/customers/customersList.js';
 import { TOAST_MESSAGES } from '../../../data/messages/messages.js';
 import { validateToastMessage } from '../../../utils/validation/toastMessage.js';
-import { logStep } from '../../../utils/report/logStep.js';
+import { logStep } from '../../../utils/report/decorator.js';
 
 export class CustomersListService {
   private customersPage: CustomersListPage;
@@ -27,6 +27,7 @@ export class CustomersListService {
     [CUSTOMERS_COLUMN_NAME.CREATED_ON]: 'createdOn',
   };
 
+  @logStep('Open Add New Customer Page')
   async openAddNewCustomerPage() {
     await this.customersPage.clickOnAddNewCustomer();
     await this.addNewCustomerPage.waitForOpened();
@@ -39,7 +40,7 @@ export class CustomersListService {
     }
   }
 
-  @logStep()
+  @logStep('Click on column')
   private async clickToSortColumn(column: CUSTOMERS_COLUMN_NAME, direction: 'asc' | 'desc') {
     let clickCount: 1 | 2;
     direction === 'asc' ? (clickCount = 1) : (clickCount = 2);
@@ -49,7 +50,7 @@ export class CustomersListService {
     );
   }
 
-  @logStep()
+  @logStep('Get all customers via UI')
   private async getAllCustomersUI() {
     const data = await this.customersPage.getCustomersColumns();
     const customers: ICustomersTable[] = [];
@@ -87,7 +88,7 @@ export class CustomersListService {
     return customers;
   }
 
-  @logStep()
+  @logStep('Sort customers and verify')
   async sortCustomersAndVerify(column: CUSTOMERS_COLUMN_NAME, direction: 'asc' | 'desc') {
     const key = this.columnKeyMap[column];
     const expectedData = await this.sortCustomersArray(key, direction);
@@ -97,18 +98,18 @@ export class CustomersListService {
     expect(actualData).toEqual(expectedData);
   }
 
-  @logStep()
+  @logStep('Validate toast message and close')
   async validateToastMessageAndClose(expectedMessage: string) {
     await validateToastMessage(this.customersPage, expectedMessage);
     await this.customersPage.closeToastMessage();
   }
 
-  @logStep()
+  @logStep('Validate custommer created message')
   async validateCustomerCreatedMessage() {
     await this.validateToastMessageAndClose(TOAST_MESSAGES.CUSTOMER.CREATED);
   }
 
-  @logStep()
+  @logStep('Validate empty table')
   async validateEmptyTable(message?: string) {
     const actualMessage = await this.customersPage.getEmptyTableMessage();
     expect(actualMessage).toEqual(message ?? TABLE_MESSAGES.EMPTY_TABLE);

--- a/src/ui/services/home.service.ts
+++ b/src/ui/services/home.service.ts
@@ -3,6 +3,7 @@ import { Page } from '@playwright/test';
 import { HomePage } from '../pages/home.page.js';
 import { CustomersListPage } from '../pages/customers/customers.page.js';
 import { BASE_URL } from '../../config/environment.js';
+import { logStep } from '../../utils/report/decorator.js';
 
 export class HomeService {
   private homePage: HomePage;
@@ -12,12 +13,14 @@ export class HomeService {
     this.customersPage = new CustomersListPage(page);
   }
 
+  @logStep('Open Customers Page')
   async openCustomersPage() {
     await this.homePage.clickOnViewDetailsButton('Customers');
     await this.homePage.waitForTableSpinnerToHide();
     await this.customersPage.waitForOpened();
   }
 
+  @logStep('Open Home Page')
   async openHomePage() {
     await this.homePage.openPage(BASE_URL);
     await this.homePage.waitForOpened();

--- a/src/ui/services/signIn.service.ts
+++ b/src/ui/services/signIn.service.ts
@@ -4,7 +4,7 @@ import { ADMIN_PASSWORD, ADMIN_USERNAME, BASE_URL } from '../../config/environme
 import { IUserCredentials } from '../../data/types/user.types.js';
 import { HomePage } from '../pages/home.page.js';
 import { SignInPage } from '../pages/login.page.js';
-import { logStep } from '../../utils/report/logStep.js';
+import { logStep } from '../../utils/report/decorator.js';
 
 export class SignInService {
   private signInPage: SignInPage;
@@ -14,12 +14,12 @@ export class SignInService {
     this.homePage = new HomePage(page);
   }
 
-  @logStep()
+  @logStep('Open Sales Portal')
   async openSalesPortal() {
     await this.signInPage.openPage(BASE_URL);
   }
 
-  @logStep()
+  @logStep('Login')
   async login(credentials: IUserCredentials) {
     await this.signInPage.fillCredentialsInputs(credentials);
     await this.signInPage.clickSubmitButton();
@@ -28,7 +28,7 @@ export class SignInService {
     await this.homePage.waitForHomeSpinnersToHide();
   }
 
-  @logStep()
+  @logStep('Login as Admin')
   async loginAsAdmin() {
     await this.login({ username: ADMIN_USERNAME, password: ADMIN_PASSWORD });
   }
@@ -37,6 +37,7 @@ export class SignInService {
     await this.signInPage.fillCredentialsInputs(credentials);
   }
 
+  @logStep('Clear cookies')
   async clearCookies() {
     await this.signInPage.deleteCookies();
   }

--- a/src/ui/tests/customers/duplicate-customer-mock.spec.ts
+++ b/src/ui/tests/customers/duplicate-customer-mock.spec.ts
@@ -2,10 +2,7 @@ import { mergeTests } from '@playwright/test';
 
 import { test as servicesTest } from '../../../fixtures/services.fixtures';
 import { test as mockTest } from '../../../fixtures/mock.fixtures';
-import {
-  generateCustomerFromResponse,
-  generateNewCustomer,
-} from '../../../data/customers/generateCustomer';
+import { generateNewCustomer } from '../../../data/customers/generateCustomer';
 
 const test = mergeTests(mockTest, servicesTest);
 
@@ -14,10 +11,6 @@ test.describe('[UI] [Customers]', async function () {
     await signInPageService.openSalesPortal();
   });
 
-  // По условиям задачи нужно создать мок с кастомером, уже существующим в проекте, и завалидировать ошибку.
-  // Но, учитывая то, что валидация происходит на бэкенде, нужно подмокивать респонс с ошибкой.
-  // Т.е. создание мока с кастомером не имеет практического смысла (но в тесте я это сделал)
-
   test('Should show error when adding existing customer', async function ({
     homePageService,
     customersPageService,
@@ -25,7 +18,6 @@ test.describe('[UI] [Customers]', async function () {
     customersMockService,
   }) {
     const customer = generateNewCustomer();
-    await customersMockService.addCustomersToTableMock([generateCustomerFromResponse(customer)]);
     await homePageService.openCustomersPage();
     await customersPageService.openAddNewCustomerPage();
     await addNewCustomerPageService.fillCustomerInputs(customer);

--- a/src/utils/report/allure.reporter.ts
+++ b/src/utils/report/allure.reporter.ts
@@ -1,0 +1,47 @@
+import { test } from '@playwright/test';
+
+import { IRequestOptions, IResponse } from '../../data/types/api.types';
+
+export class AllureReporter {
+  constructor() {}
+
+  public async logApiCall(options: IRequestOptions, response: IResponse): Promise<void> {
+    const method = options.method?.toUpperCase();
+    const url = options.url;
+    await test.step(`API ${options.method?.toUpperCase()} ${options.url}`, async () => {
+      await test.step('Request', async () => {
+        if (options.headers) {
+          await test.info().attach(`Request Headers for ${method} ${url}`, {
+            body: JSON.stringify(options.headers, null, 2),
+            contentType: 'application/json',
+          });
+        }
+        if (options.data) {
+          await test.info().attach(`Request Body for ${method} ${url}`, {
+            body: JSON.stringify(options.data, null, 2),
+            contentType: 'application/json',
+          });
+        }
+      });
+
+      await test.step(`Response ${response.status}`, async () => {
+        if (response.headers) {
+          await test.info().attach(`Response Headers for ${method} ${url}`, {
+            body: JSON.stringify(response.headers, null, 2),
+            contentType: 'application/json',
+          });
+        }
+        if (response.body) {
+          await test.info().attach(`Response Body for ${method} ${url}`, {
+            body: JSON.stringify(response.body, null, 2),
+            contentType: 'application/json',
+          });
+        }
+
+        if (response.status >= 400) {
+          test.info().status = 'failed';
+        }
+      });
+    });
+  }
+}

--- a/src/utils/report/decorator.ts
+++ b/src/utils/report/decorator.ts
@@ -27,3 +27,25 @@ export function logStep<This, Args extends any[], Return>(message?: string) {
     return replacementMethod;
   };
 }
+
+export function logAction<This, Args extends any[], Return>(stepTemplate: string) {
+  return function actualDecorator(
+    target: (this: This, ...args: Args) => Promise<Return>,
+    context: ClassMethodDecoratorContext<This, (this: This, ...args: Args) => Promise<Return>>,
+  ) {
+    function replacementMethod(this: This, ...args: Args): Promise<Return> {
+      let stepName = stepTemplate;
+
+      if (stepTemplate.includes('{selector}')) {
+        stepName = stepName.replace('{selector}', `"${args[0]}"`);
+      }
+      if (stepTemplate.includes('{text}') && args.length > 1) {
+        stepName = stepName.replace('{text}', `"${args[1]}"`);
+      }
+
+      return test.step(stepName, async () => target.call(this, ...args), { box: false });
+    }
+
+    return replacementMethod;
+  };
+}


### PR DESCRIPTION
This PR includes the following features and fixes:
- Added Allure reporter for API
- logStep.ts renamed to decorator.ts. Added logAction
- globalSetup now uses it's own login method - loginAsAdminForGlobalSetup(). The reason - globalSetup does not work with test.step which is used in decorators, so new method uses default Playwright-API methods