### PR TITLE
fix: remove singlton from SignInService

### DIFF
--- a/src/services/signIn.service.ts
+++ b/src/services/signIn.service.ts
@@ -10,7 +10,6 @@ import { STATUS_CODES } from '../data/types/api.types';
 import { apiConfig } from '../config/apiConfig';
 
 export class SignInService {
-  static instance: SignInService;
   private homePage: HomePage;
   private signInPage: SignInPage;
 
@@ -24,11 +23,7 @@ export class SignInService {
     this.signInPage = new SignInPage(page);
     this.homePage = new HomePage(page);
 
-    if (SignInService.instance) {
-      return SignInService.instance;
-    }
     if (token) this.token = token;
-    SignInService.instance = this;
   }
 
   async getToken(): Promise<string> {

--- a/src/ui/pages/base.page.ts
+++ b/src/ui/pages/base.page.ts
@@ -13,7 +13,7 @@ function isSelector(elementOrSelector: LocatorOrSelector): elementOrSelector is 
 }
 
 export class BasePage {
-  constructor(private page: Page) {}
+  constructor(protected page: Page) {}
 
   protected findElement(locator: LocatorOrSelector) {
     return isSelector(locator) ? this.page.locator(locator) : locator;


### PR DESCRIPTION
Singlton was removed from SignInService since it caused the error "Target page, context or browser has been closed". It doesn't work when the tests are run in parallel